### PR TITLE
paul/component-map-default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "databyss-org-workspace",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "Expressive database management tools for writers and researchers",
   "main": "index.js",
   "repository": {

--- a/packages/databyss-api/package.json
+++ b/packages/databyss-api/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@databyss-org/api",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "api",
   "main": "server.js",
   "author": "databyss-org",
   "license": "MIT",
   "peerDependencies": {
     "@bugsnag/js": "^6.3.2",
-    "@databyss-org/services": "1.1.58"
+    "@databyss-org/services": "1.1.59"
   },
   "dependencies": {
     "@babel/core": "^7.5.0",

--- a/packages/databyss-documentation/package.json
+++ b/packages/databyss-documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "databyss-documentation",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "documentation",
   "license": "MIT",
   "scripts": {

--- a/packages/databyss-notes-native/package.json
+++ b/packages/databyss-notes-native/package.json
@@ -2,7 +2,7 @@
   "name": "@databyss-org/notes-native",
   "author": "databyss-org",
   "license": "MIT",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "react": "16.9.0",
-    "@databyss-org/ui": "1.1.58"
+    "@databyss-org/ui": "1.1.59"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/databyss-notes/index.js
+++ b/packages/databyss-notes/index.js
@@ -1,11 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import NavigationProvider from '@databyss-org/ui/components/Navigation/NavigationProvider/NavigationProvider'
+import { ThemeProvider } from '@databyss-org/ui/theming'
 import App from './src/App'
 
 ReactDOM.render(
-  <NavigationProvider>
-    <App />
-  </NavigationProvider>,
+  <ThemeProvider>
+    <NavigationProvider>
+      <App />
+    </NavigationProvider>
+  </ThemeProvider>,
   document.getElementById('root')
 )

--- a/packages/databyss-notes/package.json
+++ b/packages/databyss-notes/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@databyss-org/notes",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "private": true,
   "peerDependencies": {
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "@databyss-org/ui": "1.1.58",
-    "@databyss-org/services": "1.1.58"
+    "@databyss-org/ui": "1.1.59",
+    "@databyss-org/services": "1.1.59"
   }
 }

--- a/packages/databyss-notes/src/App.js
+++ b/packages/databyss-notes/src/App.js
@@ -3,7 +3,6 @@ import SessionProvider from '@databyss-org/services/session/SessionProvider'
 import ServiceProvider from '@databyss-org/services/lib/ServiceProvider'
 import { useNavigationContext } from '@databyss-org/ui/components/Navigation/NavigationProvider/NavigationProvider'
 import NotifyProvider from '@databyss-org/ui/components/Notify/NotifyProvider'
-import { ThemeProvider } from '@databyss-org/ui/theming'
 import { Viewport } from '@databyss-org/ui'
 import Public from './Public'
 import Page from './Page'
@@ -13,21 +12,19 @@ const App = () => {
   const urlParams = new URLSearchParams(window.location.search)
 
   return (
-    <ThemeProvider>
-      <NotifyProvider>
-        <ServiceProvider>
-          <Viewport>
-            <SessionProvider
-              signUp={path === '/signup'}
-              code={urlParams.get('code')}
-              unauthorizedChildren={<Public />}
-            >
-              <Page />
-            </SessionProvider>
-          </Viewport>
-        </ServiceProvider>
-      </NotifyProvider>
-    </ThemeProvider>
+    <NotifyProvider>
+      <ServiceProvider>
+        <Viewport>
+          <SessionProvider
+            signUp={path === '/signup'}
+            code={urlParams.get('code')}
+            unauthorizedChildren={<Public />}
+          >
+            <Page />
+          </SessionProvider>
+        </Viewport>
+      </ServiceProvider>
+    </NotifyProvider>
   )
 }
 

--- a/packages/databyss-services/package.json
+++ b/packages/databyss-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databyss-org/services",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "repository": {
     "type": "git",
     "url": "https://github.com/databyss-org/databyss.git"
@@ -12,8 +12,8 @@
   "license": "MIT",
   "private": true,
   "peerDependencies": {
-    "@databyss-org/ui": "1.1.58",
-    "@databyss-org/services": "1.1.58",
+    "@databyss-org/ui": "1.1.59",
+    "@databyss-org/services": "1.1.59",
     "@bugsnag/js": "^6.3.2",
     "react": "16.9.0",
     "react-dom": "16.9.0"

--- a/packages/databyss-stories-native/package.json
+++ b/packages/databyss-stories-native/package.json
@@ -2,7 +2,7 @@
   "name": "@databyss-org/stories-native",
   "author": "databyss-org",
   "license": "MIT",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "private": true,
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "react-native-svg-transformer": "^0.13.0"
   },
   "peerDependencies": {
-    "@databyss-org/ui": "1.1.58",
+    "@databyss-org/ui": "1.1.59",
     "react": "16.9.0"
   },
   "publishConfig": {

--- a/packages/databyss-ui/components/Navigation/NavigationProvider/NavigationProvider.js
+++ b/packages/databyss-ui/components/Navigation/NavigationProvider/NavigationProvider.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext } from 'react'
 import createReducer from '@databyss-org/services/lib/createReducer'
+import componentMap from './componentMap'
 import reducer, { initialState } from './reducer'
 import * as actions from './actions'
 
@@ -40,6 +41,7 @@ const NavigationProvider = ({ children, componentMap, initialPath }) => {
 export const useNavigationContext = () => useContext(NavigationContext)
 
 NavigationProvider.defaultProps = {
+  componentMap,
   initialState,
 }
 

--- a/packages/databyss-ui/components/Navigation/NavigationProvider/componentMap.js
+++ b/packages/databyss-ui/components/Navigation/NavigationProvider/componentMap.js
@@ -1,7 +1,7 @@
 import SourceModal from '@databyss-org/ui/modules/SourcesValueList/SourceModal'
 import TopicModal from '@databyss-org/ui/modules/TopicsValueList/TopicModal'
 
-export const componentMap = {
+export default {
   SOURCE: SourceModal,
   TOPIC: TopicModal,
 }

--- a/packages/databyss-ui/editor/slate/__tests__/editable.stories.js
+++ b/packages/databyss-ui/editor/slate/__tests__/editable.stories.js
@@ -7,7 +7,6 @@ import TopicProvider from '@databyss-org/services/topics/TopicProvider'
 import topicReducer, {
   initialState as topicInitialState,
 } from '@databyss-org/services/topics/reducer'
-import { componentMap } from '@databyss-org/ui/components/Navigation/NavigationProvider/componentMap'
 import SourceProvider from '@databyss-org/services/sources/SourceProvider'
 import fetchMock from 'fetch-mock'
 
@@ -114,7 +113,7 @@ storiesOf('Cypress//Tests', module)
           initialState={sourceInitialState}
           reducer={sourceReducer}
         >
-          <NavigationProvider componentMap={componentMap}>
+          <NavigationProvider>
             <EditorProvider
               initialState={initialState}
               editableReducer={slateReducer}
@@ -151,7 +150,7 @@ storiesOf('Cypress//Tests', module)
           initialState={sourceInitialState}
           reducer={sourceReducer}
         >
-          <NavigationProvider componentMap={componentMap}>
+          <NavigationProvider>
             <EditorProvider
               initialState={emptyInitialState}
               editableReducer={slateReducer}

--- a/packages/databyss-ui/editor/slate/__tests__/editorDemo.stories.js
+++ b/packages/databyss-ui/editor/slate/__tests__/editorDemo.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react'
 import { View } from '@databyss-org/ui/primitives'
 import { ViewportDecorator } from '@databyss-org/ui/stories/decorators'
 import NavigationProvider from '@databyss-org/ui/components/Navigation/NavigationProvider/NavigationProvider'
-import { componentMap } from '@databyss-org/ui/components/Navigation/NavigationProvider/componentMap'
 import SourceProvider from '@databyss-org/services/sources/SourceProvider'
 import fetchMock from 'fetch-mock'
 import TopicProvider from '@databyss-org/services/topics/TopicProvider'
@@ -52,7 +51,7 @@ storiesOf('Demos|Editor', module)
           initialState={sourceInitialState}
           reducer={sourceReducer}
         >
-          <NavigationProvider componentMap={componentMap}>
+          <NavigationProvider>
             <EditorProvider
               initialState={emptyInitialState}
               editableReducer={slateReducer}

--- a/packages/databyss-ui/modules/SourcesValueList/SourceModal.js
+++ b/packages/databyss-ui/modules/SourcesValueList/SourceModal.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import {
+import SourceProvider, {
   useSourceContext,
   SourceLoader,
 } from '@databyss-org/services/sources/SourceProvider'
@@ -125,4 +125,8 @@ const SourceModal = ({ refId, visible, onUpdate, id }) => {
   )
 }
 
-export default SourceModal
+export default props => (
+  <SourceProvider>
+    <SourceModal {...props} />
+  </SourceProvider>
+)

--- a/packages/databyss-ui/modules/TopicsValueList/TopicModal.js
+++ b/packages/databyss-ui/modules/TopicsValueList/TopicModal.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import {
+import TopicProvider, {
   useTopicContext,
   TopicLoader,
 } from '@databyss-org/services/topics/TopicProvider'
@@ -87,4 +87,8 @@ const TopicModal = ({ refId, visible, onUpdate, id }) => {
   )
 }
 
-export default TopicModal
+export default props => (
+  <TopicProvider>
+    <TopicModal {...props} />
+  </TopicProvider>
+)

--- a/packages/databyss-ui/package.json
+++ b/packages/databyss-ui/package.json
@@ -2,7 +2,7 @@
   "name": "@databyss-org/ui",
   "author": "databyss-org",
   "license": "MIT",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "private": false,
   "repository": {
     "type": "git",
@@ -13,8 +13,8 @@
   },
   "main": "index.js",
   "peerDependencies": {
-    "@databyss-org/services": "1.1.58",
-    "@databyss-org/ui": "1.1.58",
+    "@databyss-org/services": "1.1.59",
+    "@databyss-org/ui": "1.1.59",
     "@storybook/react": "5.2.1",
     "react": "16.9.0",
     "react-dom": "16.9.0",

--- a/packages/databyss-ui/stories/Editor/slateEditable.stories.js
+++ b/packages/databyss-ui/stories/Editor/slateEditable.stories.js
@@ -21,7 +21,6 @@ import slateReducer from '@databyss-org/ui/editor/slate/page/reducer'
 import EditorPage from '@databyss-org/ui/editor/EditorPage'
 import initialState from '@databyss-org/ui/editor/state/__tests__/initialState'
 import NavigationProvider from '@databyss-org/ui/components/Navigation/NavigationProvider/NavigationProvider'
-import { componentMap } from '@databyss-org/ui/components/Navigation/NavigationProvider/componentMap'
 import { ViewportDecorator } from '../decorators'
 import colors from '../../theming/colors'
 
@@ -110,7 +109,7 @@ const Box = ({ children, ...others }) => (
 )
 
 const ProviderDecorator = storyFn => (
-  <NavigationProvider componentMap={componentMap}>
+  <NavigationProvider>
     <EditorProvider
       initialState={initialState}
       editableReducer={slateReducer}

--- a/packages/databyss-ui/stories/Editor/slateLoadSave.stories.js
+++ b/packages/databyss-ui/stories/Editor/slateLoadSave.stories.js
@@ -21,7 +21,6 @@ import topicReducer, {
   initialState as topicInitialState,
 } from '@databyss-org/services/topics/reducer'
 
-import { componentMap } from '@databyss-org/ui/components/Navigation/NavigationProvider/componentMap'
 import { initialState } from '@databyss-org/services/pages/reducer'
 import SlateContentEditable from '@databyss-org/ui/editor/slate/page/ContentEditable'
 import slateReducer from '@databyss-org/ui/editor/slate/page/reducer'
@@ -44,9 +43,7 @@ const ProviderDecorator = storyFn => (
             initialState={sourceInitialState}
             reducer={sourceReducer}
           >
-            <NavigationProvider componentMap={componentMap}>
-              {storyFn()}
-            </NavigationProvider>
+            <NavigationProvider>{storyFn()}</NavigationProvider>
           </SourceProvider>
         </TopicProvider>
       </PageProvider>


### PR DESCRIPTION
use default componentMap in NavigationProvider; wrap modals in provider dependencies (like SourceProvider for SourceModal) so they can mount anywhere