### PR TITLE
paul/pages-sidebar

### DIFF
--- a/packages/databyss-notes/src/Private.js
+++ b/packages/databyss-notes/src/Private.js
@@ -2,20 +2,24 @@ import React from 'react'
 import { PageProvider } from '@databyss-org/services'
 import SourceProvider from '@databyss-org/services/sources/SourceProvider'
 import TopicProvider from '@databyss-org/services/topics/TopicProvider'
+import { useNavigationContext } from '@databyss-org/ui/components/Navigation/NavigationProvider/NavigationProvider'
 import { Sidebar, PageContent } from '@databyss-org/ui'
 import { View } from '@databyss-org/ui/primitives'
 
-const Private = () => (
-  <PageProvider>
-    <SourceProvider>
-      <TopicProvider>
-        <View flexDirection="row" display="flex" width="100vw">
-          <Sidebar />
-          <PageContent />
-        </View>
-      </TopicProvider>
-    </SourceProvider>
-  </PageProvider>
-)
+const Private = () => {
+  const { path } = useNavigationContext()
+  return (
+    <PageProvider>
+      <SourceProvider>
+        <TopicProvider>
+          <View flexDirection="row" display="flex" width="100vw">
+            <Sidebar />
+            <PageContent key={path} />
+          </View>
+        </TopicProvider>
+      </SourceProvider>
+    </PageProvider>
+  )
+}
 
 export default Private

--- a/packages/databyss-services/pages/actions.js
+++ b/packages/databyss-services/pages/actions.js
@@ -54,28 +54,14 @@ export function fetchPageHeaders() {
 }
 
 export function savePage(state) {
-  console.log('save page', state)
   const body = cloneDeep(state)
   delete body.editableState
-  const _keys = Object.keys(state)
-  /*
-  if only name has been updated, refresh page headers
-  */
-  let _refreshPages = false
-  if (_keys.length === 1 && _keys[0] === 'page') {
-    _refreshPages = true
-  }
   return dispatch => {
     dispatch({
       type: CACHE_PAGE,
       payload: { body, id: body.page._id },
     })
-    services.savePage(body).then(() => {
-      // TODO:  HANDLE IF ERROR ON SAVING
-      if (_refreshPages) {
-        dispatch(fetchPageHeaders())
-      }
-    })
+    services.savePage(body)
   }
 }
 

--- a/packages/databyss-services/pages/reducer.js
+++ b/packages/databyss-services/pages/reducer.js
@@ -27,6 +27,9 @@ export default (state, action) => {
       const _state = cloneDeep(state)
       const _page = action.payload.body
       _state.cache[action.payload.id] = _page
+      if (_state.headerCache) {
+        _state.headerCache[_page.page._id] = _page.page
+      }
       return {
         ..._state,
       }

--- a/packages/databyss-ui/components/PageContent/PageContent.js
+++ b/packages/databyss-ui/components/PageContent/PageContent.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { PageLoader } from '@databyss-org/ui/components/Loaders'
 import { View } from '@databyss-org/ui/primitives'
 import { useSessionContext } from '@databyss-org/services/session/SessionProvider'
@@ -10,30 +10,13 @@ const PageContent = () => {
   const { getSession } = useSessionContext()
   const { account } = getSession()
   const { path, navigate } = useNavigationContext()
-  const [pageId, setPageId] = useState()
   const [readOnly, setReadOnly] = useState(false)
-  const [counter, setCounter] = useState(0)
 
-  /* temporary, handles page id routing */
-  useEffect(
-    () => {
-      const _pathList = path.split('/')
-      if (_pathList[1].length === 0) {
-        setPageId(account.defaultPage)
-        navigate(`/pages/${account.defaultPage}`)
-      }
-      if (_pathList[1] === 'pages') {
-        if (_pathList[2] !== pageId) {
-          setCounter(counter + 1)
-          setPageId(_pathList[2])
-        }
-      }
-    },
-    [path]
-  )
-
-  // TODO:
-  // TEXT CONTROL SHOULD ACCEPT TEXT VARIANT
+  const _pathList = path.split('/')
+  if (_pathList[1].length === 0) {
+    navigate(`/pages/${account.defaultPage}`)
+  }
+  const pageId = _pathList[2]
 
   const onHeaderClick = bool => {
     if (readOnly !== bool) {
@@ -50,7 +33,7 @@ const PageContent = () => {
       {pageId && (
         <PageLoader pageId={pageId}>
           {page => (
-            <View key={counter}>
+            <View>
               <PageHeader pageId={pageId} isFocused={onHeaderClick} />
               <PageBody page={page} readOnly={readOnly} />
             </View>

--- a/packages/databyss-ui/components/PageContent/PageHeader.js
+++ b/packages/databyss-ui/components/PageContent/PageHeader.js
@@ -48,7 +48,6 @@ const PageHeader = ({ isFocused, pageId }) => {
           labelVariant="bodyLarge"
           inputVariant="bodyLarge"
           labelColor="text.3"
-          multiline
           activeLabelColor="text.1"
         />
       </Text>


### PR DESCRIPTION
Changes:
- [x] Force PageContent remount by making the key the path rather than with `useEffect`
- [x] Update `PageContext.headerCache` in a `CACHE_PAGE` event, rather than forcing a `FETCH_PAGE_HEADERS` action

Todo:
- [ ] Separate collapsed sidebar component and expanded sidebar component. Their functionality is different enough to warrant separation (will discuss).
- [ ] Pages listing should highlight current page, as in mockup
- [ ] One more pass on styling to match mockup more closely (will discuss).