### PR TITLE
Mila/redesign page title

### DIFF
--- a/packages/databyss-ui/components/PageContent/PageContent.js
+++ b/packages/databyss-ui/components/PageContent/PageContent.js
@@ -34,7 +34,7 @@ const PageContainer = ({ anchor, id, onHeaderClick, page, readOnly }) => {
   return (
     <View height="100vh" overflow="scroll" p="medium">
       <View
-        mr="large"
+        mr="medium"
         alignItems="center"
         flexDirection="row"
         justifyContent="space-between"

--- a/packages/databyss-ui/components/PageContent/PageHeader.js
+++ b/packages/databyss-ui/components/PageContent/PageHeader.js
@@ -31,7 +31,7 @@ const PageHeader = ({ isFocused, pageId }) => {
   */
 
   return (
-    <View p="medium" flexGrow={1}>
+    <View p="medium" flexGrow={1} ml="extraSmall">
       <TextInput
         onBlur={updatePageName}
         onFocus={() => isFocused(true)}

--- a/packages/databyss-ui/components/PageContent/PageHeader.js
+++ b/packages/databyss-ui/components/PageContent/PageHeader.js
@@ -2,15 +2,20 @@ import React, { useState, useEffect } from 'react'
 import { usePageContext } from '@databyss-org/services/pages/PageProvider'
 import { View, TextInput } from '@databyss-org/ui/primitives'
 
+const noPageTitle = 'untitled'
+
 const PageHeader = ({ isFocused, pageId }) => {
   const { getPage, setPage } = usePageContext()
-
   const [pageName, setPageName] = useState({ textValue: '' })
 
   useEffect(
     () => {
       const pageData = getPage(pageId)
-      setPageName({ textValue: pageData.page.name })
+      const pageDataName = pageData.page.name
+
+      if (pageDataName !== noPageTitle) {
+        setPageName({ textValue: pageDataName })
+      }
     },
     [pageId]
   )
@@ -21,7 +26,10 @@ const PageHeader = ({ isFocused, pageId }) => {
 
   const updatePageName = () => {
     const _pageData = {
-      page: { name: pageName.textValue, _id: pageId },
+      page: {
+        name: pageName.textValue ? pageName.textValue : noPageTitle,
+        _id: pageId,
+      },
     }
     setPage(_pageData)
     isFocused(false)

--- a/packages/databyss-ui/components/PageContent/PageHeader.js
+++ b/packages/databyss-ui/components/PageContent/PageHeader.js
@@ -13,7 +13,9 @@ const PageHeader = ({ isFocused, pageId }) => {
       const pageData = getPage(pageId)
       const pageDataName = pageData.page.name
 
-      if (pageDataName !== noPageTitle) {
+      if (pageDataName === noPageTitle) {
+        setPageName({ textValue: '' })
+      } else {
         setPageName({ textValue: pageDataName })
       }
     },
@@ -42,6 +44,7 @@ const PageHeader = ({ isFocused, pageId }) => {
     <View p="medium" flexGrow={1} ml="extraSmall">
       <TextInput
         onBlur={updatePageName}
+        autoFocus
         onFocus={() => isFocused(true)}
         onKeyDown={e => {
           if (e.key === 'Enter') {

--- a/packages/databyss-ui/components/PageContent/PageHeader.js
+++ b/packages/databyss-ui/components/PageContent/PageHeader.js
@@ -44,7 +44,6 @@ const PageHeader = ({ isFocused, pageId }) => {
     <View p="medium" flexGrow={1} ml="extraSmall">
       <TextInput
         onBlur={updatePageName}
-        autoFocus
         onFocus={() => isFocused(true)}
         onKeyDown={e => {
           if (e.key === 'Enter') {

--- a/packages/databyss-ui/components/PageContent/PageHeader.js
+++ b/packages/databyss-ui/components/PageContent/PageHeader.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
-import { pxUnits } from '@databyss-org/ui/theming/views'
 import { usePageContext } from '@databyss-org/services/pages/PageProvider'
-import { Text, View, TextControl } from '@databyss-org/ui/primitives'
+import { View, TextInput } from '@databyss-org/ui/primitives'
 
 const PageHeader = ({ isFocused, pageId }) => {
   const { getPage, setPage } = usePageContext()
@@ -20,7 +19,7 @@ const PageHeader = ({ isFocused, pageId }) => {
     setPageName(val)
   }
 
-  const onBlur = () => {
+  const updatePageName = () => {
     const _pageData = {
       page: { name: pageName.textValue, _id: pageId },
     }
@@ -28,24 +27,25 @@ const PageHeader = ({ isFocused, pageId }) => {
     isFocused(false)
   }
   /*
-  header input too long maxwidth 500
   alphabatize pages
   */
 
   return (
-    <View p="medium" flex="1" maxWidth="500px">
-      <Text variant="bodyLarge" color="text.3" maxWidth={pxUnits(500)}>
-        <TextControl
-          onBlur={onBlur}
-          onFocus={() => isFocused(true)}
-          value={pageName}
-          onChange={onPageNameChange}
-          labelVariant="bodyLarge"
-          inputVariant="bodyLarge"
-          labelColor="text.3"
-          activeLabelColor="text.1"
-        />
-      </Text>
+    <View p="medium" flexGrow={1}>
+      <TextInput
+        onBlur={updatePageName}
+        onFocus={() => isFocused(true)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            updatePageName()
+          }
+        }}
+        value={pageName}
+        onChange={onPageNameChange}
+        placeholder="Enter title"
+        variant="bodyLarge"
+        color="text.3"
+      />
     </View>
   )
 }

--- a/packages/databyss-ui/components/PageContent/PageHeader.js
+++ b/packages/databyss-ui/components/PageContent/PageHeader.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react'
 import { usePageContext } from '@databyss-org/services/pages/PageProvider'
 import { View, TextInput } from '@databyss-org/ui/primitives'
+import { theme } from '@databyss-org/ui/theming'
+import styledCss from '@styled-system/css'
 
 const noPageTitle = 'untitled'
 
@@ -55,6 +57,12 @@ const PageHeader = ({ isFocused, pageId }) => {
         placeholder="Enter title"
         variant="bodyLarge"
         color="text.3"
+        concatCss={styledCss({
+          '::placeholder': {
+            color: 'text.3',
+            opacity: 0.6,
+          },
+        })(theme)}
       />
     </View>
   )

--- a/packages/databyss-ui/components/Sidebar/SidebarList.js
+++ b/packages/databyss-ui/components/Sidebar/SidebarList.js
@@ -96,8 +96,8 @@ const SidebarList = ({ menuItems = defaultMenu }) => {
             onClick={() => onClick(item)}
           >
             <View>
-              <Grid singleRow alignItems="center" columnGap="small">
-                <Icon sizeVariant="tiny" color="text.3">
+              <Grid singleRow flexWrap="nowrap" columnGap="small">
+                <Icon sizeVariant="tiny" color="text.3" mt={pxUnits(2)}>
                   {menuSvgs(item.type)}
                 </Icon>
                 <Text


### PR DESCRIPTION
Things changed:
1) Page title is now a TextInput component instead of TextControl
2) I set a placeholder "Enter title" when there is no page title set
3) If you enter a page title and then delete it later, the name of the page will be 'untitled' instead of an empty string (right now in the sidebar you would see the icon with empty space, see screenshot below)
![Screenshot 2020-05-03 at 14 26 58](https://user-images.githubusercontent.com/41082332/80914170-2f5de380-8d4a-11ea-8fe5-d645a461c4bc.png)
4) Fixed a wrapping issue in the sidebar where the page title would wrap below the icon 
![Screenshot 2020-05-03 at 12 15 11](https://user-images.githubusercontent.com/41082332/80914118-daba6880-8d49-11ea-886e-064d7bb7f21f.png)

What it looks like now:
![Screenshot 2020-05-03 at 14 53 28 2](https://user-images.githubusercontent.com/41082332/80914755-f1fb5500-8d4d-11ea-9730-b1b7d02d842a.png)


 