### PR TITLE
Render user-specific IDE settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ build/
 local.properties
 *.iml
 
+# VSCode
+.vscode
+
 # BUCK
 buck-out/
 \.buckd/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "editor.codeActionsOnSave": {
-        "source.fixAll": true
-    }    
-}


### PR DESCRIPTION
This PR deletes the `.vscode` directory and adds it to `.gitignore` so that users can have their own and not commit the differences.