### PR TITLE
Fixed page sticky covering PDF drop zone

### DIFF
--- a/packages/databyss-ui/components/PDFDropZone/DashedArea.js
+++ b/packages/databyss-ui/components/PDFDropZone/DashedArea.js
@@ -45,6 +45,7 @@ const DashedArea = props => {
 
   const render = () => (
     <StyledArea
+      zIndex="modal"
       className="dashed-area"
       bottom={getBottom()}
       opacity={getOpacity()}

--- a/packages/databyss-ui/components/PDFDropZone/PDFDropZoneManager.js
+++ b/packages/databyss-ui/components/PDFDropZone/PDFDropZoneManager.js
@@ -29,7 +29,6 @@ const viewStyles = () => ({
   overflow: 'hidden',
   pointerEvents: 'none',
   width: '96%',
-  zIndex: '10',
 })
 
 const StyledView = styled(View, viewStyles)

--- a/packages/databyss-ui/components/PageContent/PageContent.js
+++ b/packages/databyss-ui/components/PageContent/PageContent.js
@@ -64,8 +64,8 @@ const PageContainer = React.memo(({ anchor, id, page }) => {
 
   return (
     <View height="100vh" overflow="scroll" ref={editorWindowRef}>
-      <View pl="medium" pr="medium" pb="medium" zIndex={1}>
-        <PageSticky pagePath={editorPath} pageId={page._id} />
+      <PageSticky pagePath={editorPath} pageId={page._id} />
+      <View pl="medium" pr="medium" pb="medium">
         <View
           mr="medium"
           alignItems="center"

--- a/packages/databyss-ui/components/PageContent/PageContent.js
+++ b/packages/databyss-ui/components/PageContent/PageContent.js
@@ -64,8 +64,8 @@ const PageContainer = React.memo(({ anchor, id, page }) => {
 
   return (
     <View height="100vh" overflow="scroll" ref={editorWindowRef}>
-      <PageSticky pagePath={editorPath} pageId={page._id} />
       <View pl="medium" pr="medium" pb="medium" zIndex={1}>
+        <PageSticky pagePath={editorPath} pageId={page._id} />
         <View
           mr="medium"
           alignItems="center"

--- a/packages/databyss-ui/components/PageContent/PageSticky.js
+++ b/packages/databyss-ui/components/PageContent/PageSticky.js
@@ -47,7 +47,7 @@ const PageSticky = ({ pagePath, pageId }) => {
       backgroundColor="gray.7"
       position="sticky"
       top={0}
-      zIndex={2}
+      zIndex="sticky"
     >
       <Text color="gray.4" pl="medium" variant="uiTextSmall">
         <div

--- a/packages/databyss-ui/theming/zindex.js
+++ b/packages/databyss-ui/theming/zindex.js
@@ -1,5 +1,6 @@
 export default {
   base: 10,
+  sticky: 15,
   activeControl: 20,
   menu: 30,
   modal: 40,


### PR DESCRIPTION
Dashed area now covers the whole page:

![image](https://user-images.githubusercontent.com/1410355/89905170-d65ae280-dbb7-11ea-8c48-ddc7fe4703c2.png)

Sticky still covers content as you scroll:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1410355/89905250-eecafd00-dbb7-11ea-84ea-772de3c5eafd.png">

Fixes #369 
