### PR TITLE
fix

### DIFF
--- a/packages/databyss-editor/components/ContentEditable.js
+++ b/packages/databyss-editor/components/ContentEditable.js
@@ -256,11 +256,14 @@ const ContentEditable = ({
         ((_nextIsBreak && !_prevIsBreak) || (!_nextIsBreak && _prevIsBreak)) &&
         _text.length !== _offset
       ) {
+        // look behind two characters to see if its a double enter
+        if (_prevIsBreak && _text.charAt(_offset - 2) === `\n`) {
+          return
+        }
         event.preventDefault()
         Transforms.insertText(editor, `\n`)
         return
       }
-
       return
     }
     if (event.key === 'Backspace') {

--- a/packages/databyss-editor/components/ContentEditable.js
+++ b/packages/databyss-editor/components/ContentEditable.js
@@ -251,6 +251,15 @@ const ContentEditable = ({
         Transforms.move(editor, { unit: 'character', distance: 1 })
         return
       }
+      // if return is pressed in the middle of an entry
+      if (
+        ((_nextIsBreak && !_prevIsBreak) || (!_nextIsBreak && _prevIsBreak)) &&
+        _text.length !== _offset
+      ) {
+        event.preventDefault()
+        Transforms.insertText(editor, `\n`)
+        return
+      }
 
       return
     }

--- a/packages/databyss-editor/state/EditorProvider.tsx
+++ b/packages/databyss-editor/state/EditorProvider.tsx
@@ -99,7 +99,7 @@ const useReducer = createReducer()
 /*
 actions to set block relations
 */
-const isSetBlockRelations = [SPLIT, MERGE, REMOVE, , COPY]
+const isSetBlockRelations: string[] = []
 
 /*
 actions to clear block relations, then set new relations
@@ -110,6 +110,9 @@ const isClearBlockRelations = [
   CLEAR,
   DEQUEUE_NEW_ENTITY,
   REMOVE_AT_SELECTION,
+  MERGE,
+  SPLIT,
+  REMOVE,
 ]
 
 export const EditorContext = createContext<ContextType | null>(null)

--- a/packages/databyss-editor/state/reducer.ts
+++ b/packages/databyss-editor/state/reducer.ts
@@ -401,11 +401,19 @@ export default (
           }
 
           // add or insert a new block
+          const __text = payload.text
+          if(__text.textValue.charAt(0) === '\n'){
+            // prevent first character of new block being a new line
+            __text.textValue = payload.text.textValue.substring(1)
+            __text.ranges =  offsetRanges(payload.text.ranges, 1)
+          }
+   
+
           const _id = new ObjectId().toHexString()
           const _block: Block = {
             type: BlockType.Entry,
             _id,
-            text: payload.text,
+            text: __text,
           }
 
           if (payload.previous.textValue.length === 0) {
@@ -671,12 +679,13 @@ export default (
           !selectionHasRange(draft.selection) &&
           !_selectedBlock.text.textValue.length
 
+        // do not allow menu if current block contains a line break
         _selectedBlock.__showCitationMenu = _selectedBlock.text.textValue.startsWith(
           '@'
-        )
+        ) && !(_selectedBlock.text.textValue.search('\n') > -1)
         _selectedBlock.__showTopicMenu = _selectedBlock.text.textValue.startsWith(
           '#'
-        )
+        ) && !(_selectedBlock.text.textValue.search('\n') > -1)
 
         // flag blocks with `__isActive` if selection is collapsed and within an atomic element
         _selectedBlock.__isActive =

--- a/packages/databyss-editor/state/reducer.ts
+++ b/packages/databyss-editor/state/reducer.ts
@@ -446,11 +446,13 @@ export default (
           const _prevTextValue = payload.previous.textValue
 
           if (_prevTextValue.charAt(_prevTextValue.length - 1) === '\n') {
+            // if end of previous block is to new lines, remove two '\n'
+            const returnsToRemove = (_prevTextValue.charAt(_prevTextValue.length - 2) === '\n') ? 2:1
             draft.blocks[
               payload.index
             ].text.textValue = _prevTextValue.substring(
               0,
-              _prevTextValue.length - 1
+              _prevTextValue.length - returnsToRemove
             )
           }
 


### PR DESCRIPTION
* allows returns in the middle of an entry
* Trim empty line after double enter in the middle of entry with multiple lines: it creates a new block, and cursor is in front of the first word of that new block
* `#` and `@` should not function if a block has multiple lines
* If you do a double enter right before the first letter of a line, it should now create a new block