### PR TITLE
fix pdf import persistence bug

### DIFF
--- a/packages/databyss-data/pouchdb/utils.ts
+++ b/packages/databyss-data/pouchdb/utils.ts
@@ -1,6 +1,10 @@
 import PouchDB from 'pouchdb'
 import { throttle, debounce } from 'lodash'
-import { Author, Group } from '@databyss-org/services/interfaces'
+import {
+  Author,
+  BlockReference,
+  Group,
+} from '@databyss-org/services/interfaces'
 import { QueryClient } from '@tanstack/query-core'
 import { getAccountFromLocation } from '@databyss-org/services/session/utils'
 import { DocumentType, UserPreference } from './interfaces'
@@ -283,9 +287,9 @@ export const upsertImmediate = ({
  * PouchDB, bypassing the write queue. Use after synchronous state mutations that
  * must survive immediate navigation (e.g. PDF drop).
  */
-export const upsertPageImmediate = (
+export const updatePageImmediate = (
   pageId: string,
-  blocks: { _id: string; type: string }[]
+  blocks: BlockReference[]
 ): Promise<PouchDB.UpsertResponse> =>
   upsertPouch(pageId, {
     blocks: blocks.map((b) => ({ _id: b._id, type: b.type })),

--- a/packages/databyss-data/pouchdb/utils.ts
+++ b/packages/databyss-data/pouchdb/utils.ts
@@ -278,6 +278,20 @@ export const upsertImmediate = ({
   return upsertPouch(_id, _doc)
 }
 
+/**
+ * Atomically persists a page's blocks array and modifiedAt timestamp directly to
+ * PouchDB, bypassing the write queue. Use after synchronous state mutations that
+ * must survive immediate navigation (e.g. PDF drop).
+ */
+export const upsertPageImmediate = (
+  pageId: string,
+  blocks: { _id: string; type: string }[]
+): Promise<PouchDB.UpsertResponse> =>
+  upsertPouch(pageId, {
+    blocks: blocks.map((b) => ({ _id: b._id, type: b.type })),
+    modifiedAt: Date.now(),
+  })
+
 export const upsertUserPreferences = (
   prefs: Partial<UserPreference>
 ): Promise<PouchDB.UpsertResponse> => {

--- a/packages/databyss-ui/components/DropZone/DropZoneManager.tsx
+++ b/packages/databyss-ui/components/DropZone/DropZoneManager.tsx
@@ -6,6 +6,7 @@ import { useEditorContext } from '@databyss-org/editor/state/EditorProvider'
 import { useEditorPageContext } from '@databyss-org/services/editorPage/EditorPageProvider'
 import { fileIsPDF, processPDF } from '@databyss-org/services/pdf'
 import { setSource } from '@databyss-org/data/pouchdb/sources'
+import { EM, upsertPageImmediate } from '@databyss-org/data/pouchdb/utils'
 import { formatSource } from '@databyss-org/services/sources/lib'
 import { useNavigationContext } from '../../components/Navigation/NavigationProvider'
 import { FileDropZone } from './FileDropZone'
@@ -129,6 +130,20 @@ export const DropZoneManager = () => {
             : _processResults.source
           const _blocks = toDatabyssBlocks(_source, _processResults.annotations)
           insert(_blocks)
+          // Atomically persist the updated page blocks, bypassing the write queue.
+          // bulkDocs (used by EM.process) is a multi-step async operation in the
+          // main process that can race with populatePage's get IPC on quick navigation.
+          // upsertPageImmediate uses pouchdb-upsert's CAS loop, which is atomic.
+          // eslint-disable-next-line dot-notation
+          const _editorState = editorContext.stateRef?.['current']
+          if (_editorState?.pageHeader?._id) {
+            await upsertPageImmediate(
+              _editorState.pageHeader._id,
+              _editorState.blocks
+            )
+          }
+          // Also flush individual block docs (annotations etc.) to the queue.
+          await EM.process()
         } catch (error) {
           console.error(error)
           showAlert(

--- a/packages/databyss-ui/components/DropZone/DropZoneManager.tsx
+++ b/packages/databyss-ui/components/DropZone/DropZoneManager.tsx
@@ -6,7 +6,7 @@ import { useEditorContext } from '@databyss-org/editor/state/EditorProvider'
 import { useEditorPageContext } from '@databyss-org/services/editorPage/EditorPageProvider'
 import { fileIsPDF, processPDF } from '@databyss-org/services/pdf'
 import { setSource } from '@databyss-org/data/pouchdb/sources'
-import { EM, upsertPageImmediate } from '@databyss-org/data/pouchdb/utils'
+import { EM, updatePageImmediate } from '@databyss-org/data/pouchdb/utils'
 import { formatSource } from '@databyss-org/services/sources/lib'
 import { useNavigationContext } from '../../components/Navigation/NavigationProvider'
 import { FileDropZone } from './FileDropZone'
@@ -134,16 +134,16 @@ export const DropZoneManager = () => {
           // bulkDocs (used by EM.process) is a multi-step async operation in the
           // main process that can race with populatePage's get IPC on quick navigation.
           // upsertPageImmediate uses pouchdb-upsert's CAS loop, which is atomic.
-          // eslint-disable-next-line dot-notation
-          const _editorState = editorContext.stateRef?.['current']
+          const stateRef = editorContext.stateRef as React.MutableRefObject<
+            any
+          > | null
+          const _editorState = stateRef?.current
           if (_editorState?.pageHeader?._id) {
-            await upsertPageImmediate(
+            await updatePageImmediate(
               _editorState.pageHeader._id,
               _editorState.blocks
             )
           }
-          // Also flush individual block docs (annotations etc.) to the queue.
-          await EM.process()
         } catch (error) {
           console.error(error)
           showAlert(
@@ -152,6 +152,8 @@ export const DropZoneManager = () => {
             error as Error
           )
         }
+        // Also flush individual block docs (annotations etc.) to the queue.
+        await EM.process()
       } else {
         await processImage(file)
       }


### PR DESCRIPTION
This pull request introduces an atomic persistence mechanism for saving a page's blocks directly to PouchDB, bypassing the write queue. This change ensures that synchronous state mutations (such as after a PDF drop) are immediately persisted, preventing data loss during rapid navigation events. The update is integrated into the PDF drop flow in the `DropZoneManager` component.

Key changes:

**Persistence improvements:**

* Added a new `upsertPageImmediate` function in `utils.ts` to atomically persist a page's blocks array and `modifiedAt` timestamp directly to PouchDB, bypassing the write queue. This uses pouchdb-upsert's compare-and-swap (CAS) loop for atomicity.

**Integration with PDF drop flow:**

* Updated `DropZoneManager.tsx` to call `upsertPageImmediate` after inserting blocks from a processed PDF. This ensures the updated page state is immediately persisted and avoids race conditions with navigation and multi-step async operations.
* Imported the new `upsertPageImmediate` function into `DropZoneManager.tsx`.